### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b662d08e94a6c8e715abef5e10e6fdf47c2be6375a5bb246b65c177d575eb7"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,12 +129,14 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.1.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21ca434f8108ce09fd996dc1c5baae71c8aed4a240a399ecc13982b8b484f30"
+checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
 dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
  "serde",
- "static_assertions",
 ]
 
 [[package]]
@@ -242,6 +253,12 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "lazy_static"
@@ -501,6 +518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "rustyline"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +546,12 @@ dependencies = [
  "utf8parse",
  "winapi",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "scopeguard"
@@ -560,12 +589,6 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,6 +12,6 @@ eyre = "0.6.5"
 linkme = "0.2.6"
 macros = { path = "../macros" }
 rustyline = "9.0.0"
-compact_str = { version = "0.1.0", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 im = "15.0.0"
 gcmodule = "0.3.3"

--- a/crates/core/src/input_gobbler.rs
+++ b/crates/core/src/input_gobbler.rs
@@ -1,11 +1,11 @@
 use std::collections::VecDeque;
 
 use crate::Result;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 
 pub struct InputGobbler {
     readline: rustyline::Editor<()>, // TODO: a variant for files would be useful as well
-    tokens: VecDeque<CompactStr>,    // TODO: optimize allocations
+    tokens: VecDeque<CompactString>,    // TODO: optimize allocations
 }
 
 impl InputGobbler {
@@ -15,7 +15,7 @@ impl InputGobbler {
         InputGobbler { readline, tokens }
     }
 
-    pub fn next(&mut self) -> Result<Option<CompactStr>> {
+    pub fn next(&mut self) -> Result<Option<CompactString>> {
         let mut num = 0;
         loop {
             if let Some(token) = self.tokens.pop_front() {
@@ -35,7 +35,7 @@ impl InputGobbler {
         }
     }
 
-    pub fn push_front(&mut self, words: impl DoubleEndedIterator<Item = CompactStr>) {
+    pub fn push_front(&mut self, words: impl DoubleEndedIterator<Item = CompactString>) {
         for word in words.rev() {
             self.tokens.push_front(word) // TODO: why isn't there a push_front_all or sth???
         }
@@ -44,6 +44,6 @@ impl InputGobbler {
 
 // TODO: allocations
 // TODO: some tokens should be treated with extra care, ex. "{foo bar}" => ["{", "foo", "bar", "}"]
-fn tokenize(input: &str) -> impl Iterator<Item = CompactStr> + '_ {
+fn tokenize(input: &str) -> impl Iterator<Item = CompactString> + '_ {
     input.split_whitespace().map(Into::into)
 }

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -1,5 +1,5 @@
 use color_eyre::Result;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use eyre::eyre;
 use gcmodule::{ThreadedCc, Trace};
 use std::{fmt::Debug, hash::Hash, ops::Deref};
@@ -11,7 +11,7 @@ use crate::Vm;
 #[derive(Clone, Debug, PartialEq)]
 pub enum OdraValue {
     Number(f64),
-    String(CompactStr), // compact str has atomically reference counted strings and a few nice small-size optimizations
+    String(CompactString), // compact str has atomically reference counted strings and a few nice small-size optimizations
     List(im::Vector<OdraRef>),
     Map(im::HashMap<OdraRef, OdraRef>),
 }
@@ -97,7 +97,7 @@ impl Trace for OdraValue {
 pub enum OdraType {
     Number,
     String,
-    OtherNamed(CompactStr),
+    OtherNamed(CompactString),
 }
 
 pub trait AsOdraValue: AsOdraType {

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -1,5 +1,5 @@
 use color_eyre::Result;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use eyre::{eyre, WrapErr};
 
 use crate::AsOdraValue;
@@ -15,7 +15,7 @@ pub struct Vm {
 }
 
 pub struct Fibre {
-    name: CompactStr,
+    name: CompactString,
     pub stack: im::Vector<OdraValue>,
 }
 
@@ -48,7 +48,7 @@ impl Vm {
     }
 
     #[inline]
-    pub fn run(&mut self, unresolved_word: CompactStr) -> Result<()> {
+    pub fn run(&mut self, unresolved_word: CompactString) -> Result<()> {
         let word = self.vocabulary.resolve(unresolved_word)?;
 
         word.exec(self);
@@ -91,17 +91,17 @@ mod vocabulary {
     type VocabRef = Arc<RwLock<VocabInner>>;
     type VocabWeak = Weak<RwLock<VocabInner>>;
     pub struct Vocabulary {
-        all_vocabs: HashMap<CompactStr, VocabRef>,
+        all_vocabs: HashMap<CompactString, VocabRef>,
         current: VocabRef,
         root: VocabRef,
     }
 
     struct VocabInner {
         /// must be unique, TODO: semantic unsafe constructor?
-        id: CompactStr,
+        id: CompactString,
         parent: VocabWeak,
-        words: HashMap<CompactStr, &'static dyn Word>, // TODO: leakage!
-        children: HashMap<CompactStr, VocabRef>,
+        words: HashMap<CompactString, &'static dyn Word>, // TODO: leakage!
+        children: HashMap<CompactString, VocabRef>,
     }
 
     impl Eq for VocabInner {}
@@ -119,7 +119,7 @@ mod vocabulary {
 
     impl Vocabulary {
         pub fn empty() -> Vocabulary {
-            let key: CompactStr = "root".into();
+            let key: CompactString = "root".into();
             let root = Arc::new(RwLock::new(VocabInner {
                 id: key.clone(),
                 parent: Weak::new(),
@@ -136,7 +136,7 @@ mod vocabulary {
             }
         }
 
-        pub fn resolve(&self, unresolved_word: CompactStr) -> Result<&'static dyn Word> {
+        pub fn resolve(&self, unresolved_word: CompactString) -> Result<&'static dyn Word> {
             self.current
                 .read()
                 .map_err(|_| eyre!("vocab lock poisoned"))?


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning